### PR TITLE
Automatically run zplug install

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -124,10 +124,7 @@ function sops_install {
 
 # Install plugins if there are plugins that have not been installed
 if ! zplug check --verbose; then
-  printf "Install? [y/N]: "
-  if read -q; then
-    echo; zplug install
-  fi
+  zplug install
 fi
 
 zplug load


### PR DESCRIPTION
If there are zplug plugins that haven't been installed, install them automatically. There's really no situation where I would opt not to install the plugins.