### PR TITLE
feat: Add ssm-node k9s plugin

### DIFF
--- a/.config/k9s/plugins.yaml
+++ b/.config/k9s/plugins.yaml
@@ -1,7 +1,7 @@
 plugins:
   # Create debug container for selected pod in current namespace.
   # See https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#ephemeral-container
-  debug:
+  debug-container:
     shortCut: Shift-D
     description: Add debug container
     dangerous: true
@@ -13,3 +13,16 @@ plugins:
     args:
       - -c
       - "kubectl debug -it --context $CONTEXT --namespace $NAMESPACE $POD --target=$NAME --image=ubuntu --share-processes -- bash"
+
+  ssm-node:
+    shortCut: s
+    description: Start SSM Session
+    dangerous: true
+    scopes:
+      - nodes
+    command: bash
+    background: false
+    confirm: true
+    args:
+      - -c
+      - user=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"$CONTEXT\")].context.user}"); profile=$(kubectl config view -o jsonpath="{.users[?(@.name == \"$user\")].user.exec.env[0].value}"); instance_id=$(aws ec2 describe-instances --profile "$profile" --filters "Name=private-dns-name,Values=$NAME" --query "Reservations[*].Instances[*].InstanceId" --output text); aws ssm start-session --profile "$profile" --target "$instance_id"

--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -116,9 +116,9 @@ install_dependencies() {
     install_neovim >/dev/null 2>&1
   elif [ "${ADJUSTED_ID}" = "darwin" ]; then
     brew tap homebrew/cask-fonts
-    brew install --casks dbeaver-community font-space-mono-nerd-font wezterm
+    brew install --casks dbeaver-community devtoys font-space-mono-nerd-font wezterm
     check_packages ack atuin derailed/k9s/k9s dive fzf gh gnupg hadolint helm \
-      jordanbaird-ice jq kind neovim ripgrep shellcheck sslscan step \
+      jordanbaird-ice jq k6 kind neovim ripgrep shellcheck sslscan step \
       terraform-ls tmux tree-sitter yq yt-dlp
   fi
 


### PR DESCRIPTION
* Adds plugin `ssm-node` to `k9s` which enables quick creation of an ssm session to a k8s node.
* Adds `k6` and `devtoys` brew packages