### PR TITLE
fix: Add LANG and TERM env vars to .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -55,6 +55,8 @@ else
 fi
 
 export PATH=$HOME/.bin:$HOME/.nvim/bin:$PATH
+export LANG="en_US.UTF-8"
+export TERM="xterm-256color"
 
 ##################################### AWS ######################################
 


### PR DESCRIPTION
Adds `LANG` and `TERM` so that the shell behaves as expected when running in a dev container.